### PR TITLE
feat: add server tests and CI workflow for pull requests

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,20 @@
+name: test
+on:
+  pull_request:
+    branches:
+      - master
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Get go version from .tool-versions
+        id: goversion
+        run: echo goversion=$(grep '^golang ' .tool-versions | awk '{print $2}') >> $GITHUB_OUTPUT
+      - name: Setup Go
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
+        with:
+          go-version: ${{ steps.goversion.outputs.goversion }}
+      - name: Run tests
+        run: go test ./...

--- a/server/main_test.go
+++ b/server/main_test.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"context"
+	"net"
+	"testing"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	pb "google.golang.org/grpc/examples/helloworld/helloworld"
+	"google.golang.org/grpc/test/bufconn"
+)
+
+func newTestClient(t *testing.T) pb.GreeterClient {
+	t.Helper()
+	lis := bufconn.Listen(1024 * 1024)
+	t.Cleanup(func() { lis.Close() })
+
+	srv := grpc.NewServer()
+	pb.RegisterGreeterServer(srv, &server{})
+	go srv.Serve(lis) //nolint:errcheck
+	t.Cleanup(srv.Stop)
+
+	conn, err := grpc.NewClient(
+		"passthrough:///bufnet",
+		grpc.WithContextDialer(func(ctx context.Context, _ string) (net.Conn, error) {
+			return lis.DialContext(ctx)
+		}),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	if err != nil {
+		t.Fatalf("failed to create client: %v", err)
+	}
+	t.Cleanup(func() { conn.Close() })
+	return pb.NewGreeterClient(conn)
+}
+
+func TestSayHello(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"simple name", "world", "Hello world"},
+		{"empty name", "", "Hello "},
+		{"japanese", "テスト", "Hello テスト"},
+	}
+
+	client := newTestClient(t)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resp, err := client.SayHello(context.Background(), &pb.HelloRequest{Name: tt.input})
+			if err != nil {
+				t.Fatalf("SayHello(%q): %v", tt.input, err)
+			}
+			if resp.Message != tt.want {
+				t.Errorf("got %q, want %q", resp.Message, tt.want)
+			}
+		})
+	}
+}
+
+func TestSayHelloDirect(t *testing.T) {
+	s := &server{}
+	resp, err := s.SayHello(context.Background(), &pb.HelloRequest{Name: "Alice"})
+	if err != nil {
+		t.Fatalf("SayHello: %v", err)
+	}
+	if resp.Message != "Hello Alice" {
+		t.Errorf("got %q, want %q", resp.Message, "Hello Alice")
+	}
+}


### PR DESCRIPTION
## Summary

- `server/main_test.go` を追加: `bufconn` を使ったインプロセス統合テスト (`TestSayHello`) と直接ユニットテスト (`TestSayHelloDirect`)
- `.github/workflows/test.yaml` を追加: `master` ブランチへの PR 作成・更新時に `go test ./...` を実行

## Test plan

- [ ] PR 作成後に GitHub Actions の test ワークフローが自動で起動することを確認
- [ ] `TestSayHello` (bufconn 経由の統合テスト) がパスすることを確認
- [ ] `TestSayHelloDirect` (SayHello メソッドの直接呼び出し) がパスすることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)