### PR TITLE
Update distroless base image to debian13

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN cd client \
     && go mod download \
     && CGO_ENABLED=0 GOOS=linux go build
 
-FROM gcr.io/distroless/static-debian11
+FROM gcr.io/distroless/static-debian13
 WORKDIR /
 COPY --from=builder /go/src/app/client/client /client
 COPY --from=builder /go/src/app/server/server /server


### PR DESCRIPTION
## Summary
- Update the runtime base image in `Dockerfile` from `gcr.io/distroless/static-debian11` to `gcr.io/distroless/static-debian13`

## Test plan
- [x] `docker pull gcr.io/distroless/static-debian13` succeeds
- [x] Confirmed `nonroot` user (uid 65532) still exists in `/etc/passwd` of the debian13 image, so `USER nonroot` keeps working
- [ ] Full `docker build` of this Dockerfile (blocked in this sandbox by a Docker Hub auth requirement for pulling `golang:1.26.2-trixie`, unrelated to this change) — please verify in CI/locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DAaBCKjubTSv6dH4NgPGd7