### PR TITLE
Build and push container image to GHCR

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -1,0 +1,46 @@
+name: docker
+on:
+  pull_request:
+    branches:
+      - master
+  push:
+    tags:
+      - "*"
+
+env:
+  IMAGE_NAME: ghcr.io/${{ github.repository }}
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
+
+      - name: Log in to GHCR
+        if: github.event_name == 'push'
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
+        with:
+          images: ${{ env.IMAGE_NAME }}
+
+      - name: Build and push
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          push: ${{ github.event_name == 'push' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -41,6 +41,7 @@ jobs:
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           push: ${{ github.event_name == 'push' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,13 +11,17 @@ RUN cd client \
     && CGO_ENABLED=0 GOOS=linux go build \
     && cd ../server \
     && go mod download \
-    && CGO_ENABLED=0 GOOS=linux go build
+    && CGO_ENABLED=0 GOOS=linux go build \
+    && cd .. \
+    && grpc_dir="$(go list -m -f '{{.Dir}}' google.golang.org/grpc)" \
+    && mkdir -p "/out${grpc_dir}" \
+    && cp -r "${grpc_dir}/testdata" "/out${grpc_dir}/"
 
 FROM gcr.io/distroless/static-debian13
 WORKDIR /
 COPY --from=builder /go/src/app/client/client /client
 COPY --from=builder /go/src/app/server/server /server
-COPY --from=builder /go/pkg/mod/google.golang.org/grpc@v1.54.0/testdata /go/pkg/mod/google.golang.org/grpc@v1.54.0/testdata/
+COPY --from=builder /out/go /go
 USER nonroot
 EXPOSE 10000
 ENTRYPOINT ["/server"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,7 @@
-FROM golang:1.26.2-trixie as builder
+FROM --platform=$BUILDPLATFORM golang:1.26.2-trixie as builder
+
+ARG TARGETOS
+ARG TARGETARCH
 
 WORKDIR /go/src/app
 
@@ -8,10 +11,10 @@ COPY server server/
 
 RUN cd client \
     && go mod download \
-    && CGO_ENABLED=0 GOOS=linux go build \
+    && CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build \
     && cd ../server \
     && go mod download \
-    && CGO_ENABLED=0 GOOS=linux go build \
+    && CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build \
     && cd .. \
     && grpc_dir="$(go list -m -f '{{.Dir}}' google.golang.org/grpc)" \
     && mkdir -p "/out${grpc_dir}" \

--- a/README.md
+++ b/README.md
@@ -52,3 +52,13 @@ $ docker run --rm --name grpc-helloworld yteraoka/grpc-helloworld
 ```
 $ docker exec -it grpc-helloworld /client
 ```
+
+## container image (linux/amd64, linux/arm64)
+
+`Dockerfile` のビルドステージは `FROM --platform=$BUILDPLATFORM golang:...` とし、`GOOS=$TARGETOS GOARCH=$TARGETARCH` を指定した Go のクロスコンパイルでバイナリを作っている。
+
+QEMU エミュレーションでターゲットアーキテクチャ向けにビルドする方式と比べて、常にビルドホストのネイティブアーキテクチャ上で `go build` を実行できるため以下の利点がある。
+
+- QEMU エミュレーション不要のため `arm64` イメージのビルドも速い（Go コンパイラをエミュレーション環境で動かさずに済む）
+- CI 側で `docker/setup-qemu-action` などのセットアップが不要
+- 最終ステージ（distroless）には `RUN` が無いため、そちらもエミュレーション不要でビルドできる


### PR DESCRIPTION
## Summary
- Add `.github/workflows/docker.yaml`: builds the container image with `docker/build-push-action` for both `linux/amd64` and `linux/arm64`
- On pull requests to `master`: build only (`push: false`), no GHCR login needed
- On tag pushes: log in to `ghcr.io` and build & push, tagged as `ghcr.io/yteraoka/grpc-helloworld:<tag>` and `:latest` (via `docker/metadata-action`'s default semver/latest rules)
- Uses `GITHUB_TOKEN` for GHCR auth with `packages: write` permission, no extra secrets needed
- `Dockerfile` builder stage now cross-compiles natively (`FROM --platform=$BUILDPLATFORM ...` + `GOOS=$TARGETOS GOARCH=$TARGETARCH`) instead of relying on QEMU emulation, so multi-arch builds stay fast; the final distroless stage has no RUN steps so no emulation is needed there either
- Also fixes a pre-existing bug in `Dockerfile` surfaced by this new PR build gate: the `COPY --from=builder .../grpc@v1.54.0/testdata` path was hardcoded and had gone stale after Renovate bumped `google.golang.org/grpc` to v1.83.0, breaking the image build. The module cache directory is now resolved dynamically at build time (`go list -m -f '{{.Dir}}' google.golang.org/grpc`) so future dependency bumps won't break it again.

## Test plan
- [x] `actionlint` passes on the new workflow
- [x] This PR's own `pull_request` run builds the multi-arch image successfully without pushing (test / docker / goreleaser all green)
- [ ] A tag push builds and pushes the multi-arch image to GHCR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DAaBCKjubTSv6dH4NgPGd7